### PR TITLE
fix failing tests when installing, bump version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,8 @@
 include README.md
 include LICENSE
 
-recursive-include example *.py
 recursive-include example *.ipynb
 
-recursive-include lfpykit *.npz
+include lfpykit/tests/*.npz
 
 recursive-include doc *

--- a/lfpykit/tests/test_eegmegcalc.py
+++ b/lfpykit/tests/test_eegmegcalc.py
@@ -398,11 +398,8 @@ class testFourSphereVolumeConductor(unittest.TestCase):
     def test_calc_potential01(self):
         '''test comparison between analytical 4S-model and FEM simulation'''
         # load data
-        fem_sim = np.load(
-            os.path.join(
-                lfpykit.__path__[0],
-                'tests',
-                'fem_mix_dip.npz'))
+        fem_sim = np.load(os.path.join(lfpykit.__path__[0], 'tests',
+                                       'fem_mix_dip.npz'))
         pot_fem = fem_sim['pot_fem']  # [µV]
         p = fem_sim['p'].T  # [nA µm]
         rz = fem_sim['rz']  # [µm]

--- a/lfpykit/version.py
+++ b/lfpykit/version.py
@@ -1,1 +1,1 @@
-version = "0.1a2"
+version = "0.1a3"

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,12 @@ setuptools.setup(
         'meautility'
         ],
     package_data={'lfpykit': [os.path.join('tests', '*.npz')]},
+    include_package_data=True,
     extras_require={'tests': ['pytest'],
                     'docs': ['sphinx', 'numpydoc', 'sphinx_rtd_theme',
                              'recommonmark'],
                     },
     dependency_links=[],
-    provides=['lfpykit']
+    provides=['lfpykit'],
+    zip_safe=False
 )


### PR DESCRIPTION
Should take care of #69 by *not* creating a zipped .egg file in site-packages dir when running `python setup.py install`.
Bumps version number to `0.1a3`