### PR TITLE
Reimplemented calc_lfp_root_as_point(rootinds=ndarray) option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy scipy neuron=*=mpi_mpich* coveralls pytest-cov pip
   - conda activate test-environment
   - pip install git+https://github.com/LFPy/LFPy.git@2.2.dev0#egg=LFPy
+  - pip uninstall lfpykit -y  # uninstall LFPykit from LFPy installation before reinstall
   - python setup.py install
 
 script:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,7 +48,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.mathjax',
     'numpydoc',
-    # 'recommonmark',
     'm2r2'
 ]
 

--- a/lfpykit/eegmegcalc.py
+++ b/lfpykit/eegmegcalc.py
@@ -238,7 +238,6 @@ class FourSphereVolumeConductor(object):
         '''
         return self.calc_potential(np.eye(3), rz)
 
-
     def _decompose_dipole(self, p):
         """
         Decompose current dipole moment vector in radial and tangential terms

--- a/lfpykit/lfpcalc.py
+++ b/lfpykit/lfpcalc.py
@@ -399,7 +399,8 @@ def calc_lfp_linesource(cell, x, y, z, sigma, r_limit):
     return 1 / (4 * np.pi * sigma * deltaS) * mapping
 
 
-def calc_lfp_root_as_point(cell, x, y, z, sigma, r_limit):
+def calc_lfp_root_as_point(cell, x, y, z, sigma, r_limit,
+                           rootinds=np.array([0])):
     """Calculate electric field potential using the line-source method,
     root is treated as point/sphere source
 
@@ -417,11 +418,9 @@ def calc_lfp_root_as_point(cell, x, y, z, sigma, r_limit):
         extracellular conductivity in S/m
     r_limit : np.ndarray
         minimum distance to source current for each compartment.
+    rootinds: ndarray, dtype=int
+        indices of root segment(s). Defaults to np.array([0])
     """
-    # get compartment indices for root segment (to be treated as point
-    # sources)
-    rootinds = np.array([0])
-
     # some variables for h, r2, r_root calculations
     xstart = cell.x[:, 0]
     xmid = cell.x[rootinds, :].mean(axis=-1)

--- a/lfpykit/models.py
+++ b/lfpykit/models.py
@@ -517,6 +517,9 @@ class RecExtElectrode(LinearModel):
         Flag for verbose output, i.e., print more information
     seedvalue: int
         random seed when finding random position on contact with r > 0
+    **kwargs:
+        Additional keyword arguments parsed to `RecExtElectrode.lfp_method()`
+        which is determined by `method` parameter.
 
     Examples
     --------
@@ -883,13 +886,13 @@ class RecExtElectrode(LinearModel):
             else:
                 pass
 
-            M = self._lfp_el_pos_calc_dist()
+            M = self._lfp_el_pos_calc_dist(**self.kwargs)
 
             if self.verbose:
                 print('calculations finished, %s, %s' % (str(self),
                                                          str(self.cell)))
         else:
-            M = self._loop_over_contacts()
+            M = self._loop_over_contacts(**self.kwargs)
             if self.verbose:
                 print('calculations finished, %s, %s' % (str(self),
                                                          str(self.cell)))

--- a/lfpykit/tests/test_module.py
+++ b/lfpykit/tests/test_module.py
@@ -386,11 +386,10 @@ class TestSuite(unittest.TestCase):
             M = el.get_transformation_matrix()
 
             np.testing.assert_allclose(M0[0, i], M[0, i])
-            np.testing.assert_equal(M1[0, ids != i],
-                                    M[0, ids != i])
+            np.testing.assert_equal(M1[0, ids != i], M[0, ids != i])
 
         # multiple roots
-        for i in range(cell.totnsegs-1):
+        for i in range(cell.totnsegs - 1):
             rootinds = np.array([i, i + 1])
             notroots = np.ones(cell.totnsegs, dtype=bool)
             notroots[rootinds] = False
@@ -402,8 +401,7 @@ class TestSuite(unittest.TestCase):
             M = el.get_transformation_matrix()
 
             np.testing.assert_allclose(M0[0, rootinds], M[0, rootinds])
-            np.testing.assert_equal(M1[0, notroots],
-                                    M[0, notroots])
+            np.testing.assert_equal(M1[0, notroots], M[0, notroots])
 
     def test_RecMEAElectrode_00(self):
         """test RecMEAElectrode implementation,

--- a/lfpykit/tests/test_module.py
+++ b/lfpykit/tests/test_module.py
@@ -362,30 +362,34 @@ class TestSuite(unittest.TestCase):
         sigma = 0.3
         r = np.array([1, 0, 2])
         # all point sources
-        el0 = lfp.RecExtElectrode(cell=cell,
-                                  x=r[0], y=r[1], z=r[2],
-                                  sigma=sigma,
-                                  method='pointsource')
+        el0 = lfp.PointSourcePotential(cell=cell,
+                                       x=np.array([r[0]]),
+                                       y=np.array([r[1]]),
+                                       z=np.array([r[2]]),
+                                       sigma=sigma)
         M0 = el0.get_transformation_matrix()
 
         # all line sources
-        el1 = lfp.RecExtElectrode(cell=cell,
-                                  x=r[0], y=r[1], z=r[2],
-                                  sigma=sigma,
-                                  method='linesource')
+        el1 = lfp.LineSourcePotential(cell=cell,
+                                      x=np.array([r[0]]),
+                                      y=np.array([r[1]]),
+                                      z=np.array([r[2]]),
+                                      sigma=sigma)
         M1 = el1.get_transformation_matrix()
 
-        # vary which index is treated as root
+        # vary which index is treated as point
         ids = np.arange(cell.totnsegs)
         for i in range(cell.totnsegs):
             el = lfp.RecExtElectrode(cell=cell,
-                                     x=r[0], y=r[1], z=r[2],
+                                     x=r[0],
+                                     y=r[1],
+                                     z=r[2],
                                      sigma=sigma,
                                      method='root_as_point',
                                      rootinds=np.array([i]))
             M = el.get_transformation_matrix()
 
-            np.testing.assert_allclose(M0[0, i], M[0, i])
+            np.testing.assert_almost_equal(M0[0, i], M[0, i])
             np.testing.assert_equal(M1[0, ids != i], M[0, ids != i])
 
         # multiple roots

--- a/lfpykit/version.py
+++ b/lfpykit/version.py
@@ -1,1 +1,1 @@
-version = "0.1a3"
+version = "0.1a4"


### PR DESCRIPTION
`RecExtElectrode(**kwargs)` now parses parameters to chosen `lfp_method` function. 
Can be used to set `rootinds` for `lfpcalc.calc_lfp_root_as_point()` method for an arbitrary number of root segments. 
Added test `test_module::test_RecExtElectrode_04`. Bumped version number.  

Closes #65 