### PR TITLE
Avoid np.where

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -19,11 +19,11 @@ jobs:
             python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -31,8 +31,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest wheel coverage pytest-cov coveralls
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [[ "${{ matrix.python-version }}" < "3.9" ]]; then pip install neuron; fi
         pip install .
+        pip install neuron
     - name: Test with pytest and coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -8,9 +8,9 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.8"
       - name: flake8 Lint

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,9 +19,9 @@ jobs:
             python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/examples/Example_SphericallySymmetricVolCondMEG_vs_InfiniteHomogeneousVolCondMEG.ipynb
+++ b/examples/Example_SphericallySymmetricVolCondMEG_vs_InfiniteHomogeneousVolCondMEG.ipynb
@@ -14,6 +14,18 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "40203944-3ed4-46b9-94fa-208638c3880d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This example uses matplotlib widgets. Uncomment and run either line. A kernel restart may be needed\n",
+    "# !pip install ipympl  # or\n",
+    "# !conda install ipympl -y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "f5e2386c",
    "metadata": {},
    "outputs": [],
@@ -23,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "816eaac5",
    "metadata": {},
    "outputs": [],
@@ -35,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "30dc67a2",
    "metadata": {},
    "outputs": [],
@@ -59,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "a9d06789",
    "metadata": {},
    "outputs": [],
@@ -73,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "d8623405",
    "metadata": {},
    "outputs": [],
@@ -87,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c83a674f",
    "metadata": {},
    "outputs": [],
@@ -99,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "beb6b872",
    "metadata": {},
    "outputs": [],
@@ -110,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "f4bad94f",
    "metadata": {
     "scrolled": true,
@@ -123,14 +135,14 @@
        "Text(0.5, 0, 'z (µm)')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2fe6924c71fc4dbe804d10153e4a9368",
+       "model_id": "6e46dc7fa71240d695428c89fbd440cd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -173,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "cf08c0e6",
    "metadata": {
     "tags": []
@@ -185,14 +197,14 @@
        "Text(0.5, 0, 'z (µm)')"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b5b7f041f4644987b0049ab1866096e9",
+       "model_id": "d676b69090e14c319ef6a429669a6ba3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -266,7 +278,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,

--- a/lfpykit/lfpcalc.py
+++ b/lfpykit/lfpcalc.py
@@ -988,7 +988,7 @@ def calc_lfp_root_as_point_moi(cell_x, cell_y, cell_z,
     dL2 = dx2 + dy2
     # avoid denominator approaching 0
     inds = (dL2 + dz2) < (r_limit[rootinds] * r_limit[rootinds])
-    dL2[inds] = r_limit[inds] * r_limit[inds] - dz2[inds]
+    dL2[inds] = r_limit[rootinds][inds] * r_limit[rootinds][inds] - dz2[inds]
 
     def _omega(dz):
         return 1 / np.sqrt(dL2 + dz * dz)

--- a/lfpykit/lfpcalc.py
+++ b/lfpykit/lfpcalc.py
@@ -163,7 +163,7 @@ def calc_lfp_linesource_anisotropic(cell_x, cell_y, cell_z,
     if (i + iia + iib + iii + iiii).sum() != xstart.size:
         print(a, b, c)
         print(i, iia, iib, iii, iiii)
-        raise RuntimeError
+        raise RuntimeError  # WHY?
 
     mapping = np.zeros(xstart.size)
     mapping[i] = _anisotropic_line_source_case_i(a[i], c[i])
@@ -276,7 +276,7 @@ def calc_lfp_root_as_point_anisotropic(cell_x, cell_y, cell_z,
     if (i + iia + iib + iii + iiii).sum() != xstart.size:
         print(a, b, c)
         print(i, iia, iib, iii, iiii)
-        raise RuntimeError
+        raise RuntimeError  # WHY?
 
     mapping = np.zeros(xstart.size)
     mapping[i] = _anisotropic_line_source_case_i(a[i], c[i])

--- a/lfpykit/lfpcalc.py
+++ b/lfpykit/lfpcalc.py
@@ -117,7 +117,7 @@ def calc_lfp_linesource_anisotropic(cell_x, cell_y, cell_z,
          sigma[0] * sigma[2] * (y - ystart)**2 +
          sigma[0] * sigma[1] * (z - zstart)**2)
 
-    # this looks bizarre:
+    # this looks not optimal:
     for idx in np.where(rs < r_limit)[0]:
         r = rs[idx]
         closest_point = closest_points[:, idx]
@@ -231,7 +231,7 @@ def calc_lfp_root_as_point_anisotropic(cell_x, cell_y, cell_z,
          sigma[0] * sigma[2] * (y - ystart)**2 +
          sigma[0] * sigma[1] * (z - zstart)**2)
 
-    # this looks bizarre:
+    # this looks not optimal:
     for idx in np.where(rs < r_limit)[0]:
         r = rs[idx]
         closest_point = closest_points[:, idx]

--- a/lfpykit/lfpcalc.py
+++ b/lfpykit/lfpcalc.py
@@ -153,17 +153,13 @@ def calc_lfp_linesource_anisotropic(cell_x, cell_y, cell_z,
                   sigma[0] * sigma[2] * (p_[1] - ystart[idx])**2 +
                   sigma[0] * sigma[1] * (p_[2] - zstart[idx])**2)
 
-    [i] = np.where(np.abs(b) <= 1e-6)
-    [iia] = np.where(np.bitwise_and(np.abs(4 * a * c - b * b) < 1e-6,
-                                    np.abs(a - c) < 1e-6))
-    [iib] = np.where(np.bitwise_and(np.abs(4 * a * c - b * b) < 1e-6,
-                                    np.abs(a - c) >= 1e-6))
-    [iii] = np.where(np.bitwise_and(4 * a * c - b * b < -1e-6,
-                                    np.abs(b) > 1e-6))
-    [iiii] = np.where(np.bitwise_and(4 * a * c - b * b > 1e-6,
-                                     np.abs(b) > 1e-6))
+    i = np.abs(b) <= 1e-6
+    iia = (np.abs(4 * a * c - b * b) < 1e-6) & (np.abs(a - c) < 1e-6)
+    iib = (np.abs(4 * a * c - b * b) < 1e-6) & (np.abs(a - c) >= 1e-6)
+    iii = (4 * a * c - b * b < -1e-6) & (np.abs(b) > 1e-6)
+    iiii = (4 * a * c - b * b > 1e-6) & (np.abs(b) > 1e-6)
 
-    if len(i) + len(iia) + len(iib) + len(iii) + len(iiii) != xstart.size:
+    if (i + iia + iib + iii + iiii).sum() != xstart.size:
         print(a, b, c)
         print(i, iia, iib, iii, iiii)
         raise RuntimeError
@@ -270,17 +266,13 @@ def calc_lfp_root_as_point_anisotropic(cell_x, cell_y, cell_z,
                   sigma[0] * sigma[2] * (p_[1] - ystart[idx])**2 +
                   sigma[0] * sigma[1] * (p_[2] - zstart[idx])**2)
 
-    [i] = np.where(np.abs(b) <= 1e-6)
-    [iia] = np.where(np.bitwise_and(np.abs(4 * a * c - b * b) < 1e-6,
-                                    np.abs(a - c) < 1e-6))
-    [iib] = np.where(np.bitwise_and(np.abs(4 * a * c - b * b) < 1e-6,
-                                    np.abs(a - c) >= 1e-6))
-    [iii] = np.where(np.bitwise_and(4 * a * c - b * b < -1e-6,
-                                    np.abs(b) > 1e-6))
-    [iiii] = np.where(np.bitwise_and(4 * a * c - b * b > 1e-6,
-                                     np.abs(b) > 1e-6))
+    i = np.abs(b) <= 1e-6
+    iia = (np.abs(4 * a * c - b * b) < 1e-6) & (np.abs(a - c) < 1e-6)
+    iib = (np.abs(4 * a * c - b * b) < 1e-6) & (np.abs(a - c) >= 1e-6)
+    iii = (4 * a * c - b * b < -1e-6) & (np.abs(b) > 1e-6)
+    iiii = (4 * a * c - b * b > 1e-6) & (np.abs(b) > 1e-6)
 
-    if len(i) + len(iia) + len(iib) + len(iii) + len(iiii) != xstart.size:
+    if (i + iia + iib + iii + iiii).sum() != xstart.size:
         print(a, b, c)
         print(i, iia, iib, iii, iiii)
         raise RuntimeError
@@ -414,7 +406,7 @@ def _calc_lfp_linesource(xstart,
     h = _h_calc(xstart, xend, ystart, yend, zstart, zend, deltaS, x, y, z)
     r2 = _r2_calc(xend, yend, zend, x, y, z, h)
 
-    too_close_idxs = np.where(r2 < r_limit * r_limit)[0]
+    too_close_idxs = r2 < (r_limit * r_limit)
     r2[too_close_idxs] = r_limit[too_close_idxs]**2
     l_ = h + deltaS
 
@@ -426,11 +418,11 @@ def _calc_lfp_linesource(xstart,
     mapping = np.zeros(xstart.size)
 
     # case i, h < 0, l < 0, see Eq. C.13 in Gary Holt's thesis, 1998.
-    [i] = np.where(hnegi & lnegi)
+    i = hnegi & lnegi
     # case ii, h < 0, l >= 0
-    [ii] = np.where(hnegi & lposi)
+    ii = hnegi & lposi
     # case iii, h >= 0, l >= 0
-    [iii] = np.where(hposi & lposi)
+    iii = hposi & lposi
 
     mapping[i] = _linesource_calc_case1(l_[i], r2[i], h[i])
     mapping[ii] = _linesource_calc_case2(l_[ii], r2[ii], h[ii])
@@ -499,11 +491,11 @@ def calc_lfp_root_as_point(cell_x, cell_y, cell_z, x, y, z, sigma, r_limit,
 
     # Line sources
     # case i,  h < 0,  l < 0
-    i = np.where(hnegi & lnegi)
+    i = hnegi & lnegi
     # case ii,  h < 0,  l >= 0
-    ii = np.where(hnegi & lposi)
+    ii = hnegi & lposi
     # case iii,  h >= 0,  l >= 0
-    iii = np.where(hposi & lposi)
+    iii = hposi & lposi
 
     # Sum all potential contributions
     mapping = np.zeros(xstart.size)
@@ -732,7 +724,8 @@ def calc_lfp_pointsource_moi(cell_x, cell_y, cell_z,
     dz2 = (z_ - cell_z_mid)**2
 
     dL2 = dx2 + dy2
-    inds = np.where(dL2 + dz2 < r_limit * r_limit)[0]
+    # inds = np.where(dL2 + dz2 < r_limit * r_limit)[0]
+    inds = (dL2 + dz2) < (r_limit * r_limit)
     dL2[inds] = r_limit[inds] * r_limit[inds] - dz2[inds]
 
     def _omega(dz):
@@ -822,7 +815,9 @@ def calc_lfp_linesource_moi(cell_x, cell_y, cell_z,
     rs, _ = return_dist_from_segments(xstart, ystart, zstart,
                                       xend, yend, zend, pos)
     z0_ = z0.copy()
-    z0_[np.where(rs < r_limit)] = r_limit[np.where(rs < r_limit)]
+    # z0_[np.where(rs < r_limit)] = r_limit[np.where(rs < r_limit)]
+    inds = rs < r_limit
+    z0_[inds] = r_limit[inds]
 
     ds = _deltaS_calc(xstart, xend, ystart, yend, zstart, zend)
     factor_a = ds * ds
@@ -841,13 +836,13 @@ def calc_lfp_linesource_moi(cell_x, cell_y, cell_z,
         factor_c = a_x * a_x + a_y * a_y + a_z * a_z
         b_2_ac = factor_b * factor_b - factor_a * factor_c
 
-        case1_idxs = np.where(np.abs(b_2_ac) <= 1e-12)
-        case2_idxs = np.where(np.abs(b_2_ac) > 1e-12)
+        case1_idxs = np.abs(b_2_ac) <= 1e-12
+        case2_idxs = np.abs(b_2_ac) > 1e-12
 
-        if not len(case1_idxs) == 0:
+        if case1_idxs.sum() > 0:
             num[case1_idxs] = factor_a[case1_idxs] + factor_b[case1_idxs]
             den[case1_idxs] = factor_b[case1_idxs]
-        if not len(case2_idxs) == 0:
+        if case2_idxs.sum() > 0:
             num[case2_idxs] = (factor_a[case2_idxs] + factor_b[case2_idxs]
                                + ds[case2_idxs]
                                * np.sqrt(factor_a[case2_idxs]
@@ -955,13 +950,13 @@ def calc_lfp_root_as_point_moi(cell_x, cell_y, cell_z,
         factor_c = a_x * a_x + a_y * a_y + a_z * a_z
         b_2_ac = factor_b * factor_b - factor_a * factor_c
 
-        case1_idxs = np.where(np.abs(b_2_ac) <= 1e-12)
-        case2_idxs = np.where(np.abs(b_2_ac) > 1e-12)
+        case1_idxs = np.abs(b_2_ac) <= 1e-12
+        case2_idxs = np.abs(b_2_ac) > 1e-12
 
-        if len(case1_idxs) != 0:
+        if case1_idxs.sum() > 0:
             num[case1_idxs] = factor_a[case1_idxs] + factor_b[case1_idxs]
             den[case1_idxs] = factor_b[case1_idxs]
-        if len(case2_idxs) != 0:
+        if case2_idxs.sum() > 0:
             num[case2_idxs] = (factor_a[case2_idxs] + factor_b[case2_idxs] +
                                + ds[case2_idxs]
                                * np.sqrt(factor_a[case2_idxs]

--- a/lfpykit/lfpcalc.py
+++ b/lfpykit/lfpcalc.py
@@ -117,6 +117,7 @@ def calc_lfp_linesource_anisotropic(cell_x, cell_y, cell_z,
          sigma[0] * sigma[2] * (y - ystart)**2 +
          sigma[0] * sigma[1] * (z - zstart)**2)
 
+    # this looks bizarre:
     for idx in np.where(rs < r_limit)[0]:
         r = rs[idx]
         closest_point = closest_points[:, idx]
@@ -230,6 +231,7 @@ def calc_lfp_root_as_point_anisotropic(cell_x, cell_y, cell_z,
          sigma[0] * sigma[2] * (y - ystart)**2 +
          sigma[0] * sigma[1] * (z - zstart)**2)
 
+    # this looks bizarre:
     for idx in np.where(rs < r_limit)[0]:
         r = rs[idx]
         closest_point = closest_points[:, idx]
@@ -252,9 +254,8 @@ def calc_lfp_root_as_point_anisotropic(cell_x, cell_y, cell_z,
             p_[:] = pos + (pos - closest_point) * (r_limit[idx] - r) / r
 
         if np.sqrt(np.sum((p_ - closest_point)**2)) - r_limit[idx] > 1e-9:
-            print(p_, closest_point)
-
-            raise RuntimeError("Segment adjustment not working")
+            raise RuntimeError(f"Adjustment failed for segment {idx}",
+                               p_, closest_point)
 
         b[idx] = -2 * ((sigma[1] * sigma[2] * (p_[0] - xstart[idx])
                         * (xend[idx] - xstart[idx])) +
@@ -301,19 +302,17 @@ def calc_lfp_root_as_point_anisotropic(cell_x, cell_y, cell_z,
     r2_root = dx2_root + dy2_root + dz2_root
 
     # Go through and correct all (if any) root idxs that are too close
-    for close_idx in np.where(np.abs(r2_root) < 1e-6)[0]:
-        dx2_root[close_idx] += 0.001
-        r2_root[close_idx] += 0.001
+    close_idx = r2_root < 1e-6
+    dx2_root[close_idx] += 0.001
+    r2_root[close_idx] += 0.001
 
-    for close_idx in np.where(r2_root < r_limit[rootinds]**2)[0]:
-        # For anisotropic media, the direction in which to move points matter.
-        # Radial distance between point source and electrode is scaled to r_lim
-        r2_scale_factor = r_limit[rootinds[close_idx]
-                                  ] * r_limit[rootinds[close_idx]
-                                              ] / r2_root[close_idx]
-        dx2_root[close_idx] *= r2_scale_factor
-        dy2_root[close_idx] *= r2_scale_factor
-        dz2_root[close_idx] *= r2_scale_factor
+    close_idx = r2_root < r_limit[rootinds]**2
+    r2_scale_factor = r_limit[rootinds[close_idx]
+                              ] * r_limit[rootinds[close_idx]
+                                          ] / r2_root[close_idx]
+    dx2_root[close_idx] *= r2_scale_factor
+    dy2_root[close_idx] *= r2_scale_factor
+    dz2_root[close_idx] *= r2_scale_factor
 
     mapping[rootinds] = 1 / np.sqrt(sigma[1] * sigma[2] * dx2_root
                                     + sigma[0] * sigma[2] * dy2_root
@@ -476,7 +475,8 @@ def calc_lfp_root_as_point(cell_x, cell_y, cell_z, x, y, z, sigma, r_limit,
         r_root[r_root < r_limit[rootinds]
                ] = r_limit[rootinds][r_root < r_limit[rootinds]]
 
-    too_close_idxs = np.where(r2 < r_limit * r_limit)[0]
+    # avoid denominator approaching 0
+    too_close_idxs = r2 < (r_limit * r_limit)
     r2[too_close_idxs] = r_limit[too_close_idxs]**2
     l_ = h + deltaS
 
@@ -724,7 +724,7 @@ def calc_lfp_pointsource_moi(cell_x, cell_y, cell_z,
     dz2 = (z_ - cell_z_mid)**2
 
     dL2 = dx2 + dy2
-    # inds = np.where(dL2 + dz2 < r_limit * r_limit)[0]
+    # avoid denominator approaching 0
     inds = (dL2 + dz2) < (r_limit * r_limit)
     dL2[inds] = r_limit[inds] * r_limit[inds] - dz2[inds]
 
@@ -815,7 +815,7 @@ def calc_lfp_linesource_moi(cell_x, cell_y, cell_z,
     rs, _ = return_dist_from_segments(xstart, ystart, zstart,
                                       xend, yend, zend, pos)
     z0_ = z0.copy()
-    # z0_[np.where(rs < r_limit)] = r_limit[np.where(rs < r_limit)]
+    # avoid denominator approaching 0
     inds = rs < r_limit
     z0_[inds] = r_limit[inds]
 
@@ -986,7 +986,8 @@ def calc_lfp_root_as_point_moi(cell_x, cell_y, cell_z,
     dz2 = (z_ - cell_z[rootinds, :].mean(axis=-1))**2
 
     dL2 = dx2 + dy2
-    inds = np.where(dL2 + dz2 < r_limit[rootinds] * r_limit[rootinds])[0]
+    # avoid denominator approaching 0
+    inds = (dL2 + dz2) < (r_limit[rootinds] * r_limit[rootinds])
     dL2[inds] = r_limit[inds] * r_limit[inds] - dz2[inds]
 
     def _omega(dz):

--- a/lfpykit/models.py
+++ b/lfpykit/models.py
@@ -1263,7 +1263,8 @@ class RecMEAElectrode(RecExtElectrode):
             bad_comps, reason = self._return_comp_outside_slice()
             msg = ("Compartments {} of cell ({}) has cell.{} slice. "
                    "Increase squeeze_cell_factor, move or rotate cell."
-                   ).format(cell.get_idx()[bad_comps], self.cell, reason)
+                   ).format(np.arange(self.cell.totnsegs)[bad_comps],
+                            self.cell, reason)
 
             raise RuntimeError(msg)
 
@@ -1321,7 +1322,8 @@ class RecMEAElectrode(RecExtElectrode):
                 bad_comps, reason = self._return_comp_outside_slice()
                 msg = ("Compartments {} of cell ({}) has cell.{} slice "
                        "and argument squeeze_cell_factor is None."
-                       ).format(cell.get_idx()[bad_comps], self.cell, reason)
+                       ).format(np.arange(self.cell.totnsegs)[bad_comps],
+                                self.cell, reason)
                 raise RuntimeError(msg)
         else:
             if self.verbose:

--- a/lfpykit/models.py
+++ b/lfpykit/models.py
@@ -1263,7 +1263,7 @@ class RecMEAElectrode(RecExtElectrode):
             bad_comps, reason = self._return_comp_outside_slice()
             msg = ("Compartments {} of cell ({}) has cell.{} slice. "
                    "Increase squeeze_cell_factor, move or rotate cell."
-                   ).format(bad_comps, self.cell, reason)
+                   ).format(cell.get_idx()[bad_comps], self.cell, reason)
 
             raise RuntimeError(msg)
 
@@ -1281,18 +1281,18 @@ class RecMEAElectrode(RecExtElectrode):
             Numpy array with the compartments that are outside the slice,
             and a string with additional information on the problem.
         """
-        zstart_above = np.where(self.cell.z[:, 0] > self.z_shift + self.h)[0]
-        zend_above = np.where(self.cell.z[:, -1] > self.z_shift + self.h)[0]
-        zend_below = np.where(self.cell.z[:, -1] < self.z_shift)[0]
-        zstart_below = np.where(self.cell.z[:, 0] < self.z_shift)[0]
+        zstart_above = self.cell.z[:, 0] > (self.z_shift + self.h)
+        zend_above = self.cell.z[:, -1] > (self.z_shift + self.h)
+        zend_below = self.cell.z[:, -1] < self.z_shift
+        zstart_below = self.cell.z[:, 0] < self.z_shift
 
-        if len(zstart_above) > 0:
+        if zstart_above.sum() > 0:
             return zstart_above, "zstart above"
-        if len(zstart_below) > 0:
+        if zstart_below.sum() > 0:
             return zstart_below, "zstart below"
-        if len(zend_above) > 0:
+        if zend_above.sum() > 0:
             return zend_above, "zend above"
-        if len(zend_below) > 0:
+        if zend_below.sum() > 0:
             return zend_below, "zend below"
         raise RuntimeError("This function should only be called if cell"
                            "extends outside slice")
@@ -1321,7 +1321,7 @@ class RecMEAElectrode(RecExtElectrode):
                 bad_comps, reason = self._return_comp_outside_slice()
                 msg = ("Compartments {} of cell ({}) has cell.{} slice "
                        "and argument squeeze_cell_factor is None."
-                       ).format(bad_comps, self.cell, reason)
+                       ).format(cell.get_idx()[bad_comps], self.cell, reason)
                 raise RuntimeError(msg)
         else:
             if self.verbose:

--- a/lfpykit/tests/test_module.py
+++ b/lfpykit/tests/test_module.py
@@ -581,25 +581,29 @@ class TestSuite(unittest.TestCase):
         stick.z[true_bad_comp, 0] = 1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zstart above")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp,
+                                np.arange(stick.totnsegs)[bad_comp])
         stick.z[true_bad_comp, 0] = 100
 
         stick.z[true_bad_comp, 0] = -1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zstart below")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp,
+                                np.arange(stick.totnsegs)[bad_comp])
         stick.z[true_bad_comp, 0] = 100
 
         stick.z[true_bad_comp, -1] = 1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zend above")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp,
+                                np.arange(stick.totnsegs)[bad_comp])
         stick.z[true_bad_comp, -1] = 100
 
         stick.z[true_bad_comp, -1] = -1000
         bad_comp, reason = MEA._return_comp_outside_slice()
         np.testing.assert_equal(reason, "zend below")
-        np.testing.assert_equal(true_bad_comp, bad_comp)
+        np.testing.assert_equal(true_bad_comp,
+                                np.arange(stick.totnsegs)[bad_comp])
         stick.z[true_bad_comp, -1] = 100
 
     def test_RecMEAElectrode_03(self):

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         'Intended Audience :: Science/Research',
         'Development Status :: 4 - Beta',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'numpy>=1.15.2',
         'scipy',


### PR DESCRIPTION
Closes #169. Unsupports Python 3.6 (some missed references to 3.6 in #166)