### PR TITLE
Fixes bug in line source calculation

### DIFF
--- a/lfpykit/lfpcalc.py
+++ b/lfpykit/lfpcalc.py
@@ -447,7 +447,8 @@ def calc_lfp_root_as_point(cell_x, cell_y, cell_z, x, y, z, sigma, r_limit,
 
     deltaS = _deltaS_calc(xstart, xend, ystart, yend, zstart, zend)
     h = _h_calc(xstart, xend, ystart, yend, zstart, zend, deltaS, x, y, z)
-    r2 = _r2_calc(xend, yend, zend, x, y, z, h)
+    l_ = h + deltaS
+    r2 = _r2_calc(xend, yend, zend, x, y, z, l_)
     r_root = _r_root_calc(xmid, ymid, zmid, x, y, z)
     if np.any(r_root < r_limit[rootinds]):
         print('Adjusting r-distance to root segments')
@@ -457,7 +458,6 @@ def calc_lfp_root_as_point(cell_x, cell_y, cell_z, x, y, z, sigma, r_limit,
     # avoid denominator approaching 0
     too_close_idxs = r2 < (r_limit * r_limit)
     r2[too_close_idxs] = r_limit[too_close_idxs]**2
-    l_ = h + deltaS
 
     hnegi = h < 0
     hposi = h >= 0
@@ -553,9 +553,9 @@ def _r2_calc(xend,
              x,
              y,
              z,
-             h):
+             l):
     """Subroutine used by calc_lfp_*()"""
-    r2 = (xend - x)**2 + (yend - y)**2 + (zend - z)**2 - h**2
+    r2 = (xend - x)**2 + (yend - y)**2 + (zend - z)**2 - l**2
     return np.abs(r2)
 
 

--- a/lfpykit/tests/test_lfpcalc.py
+++ b/lfpykit/tests/test_lfpcalc.py
@@ -607,6 +607,36 @@ class testLfpCalc(unittest.TestCase):
                                   cell.z[:, 0], cell.z[:, -1])
         np.testing.assert_equal(ds, np.sqrt(26))
 
+    def test_calc_lfp_linesource(self):
+        
+        '''Tests that correct value is obtained for a simplified geometry'''
+
+        cell = DummyCell()
+
+        electrodeX = 2
+        electrodeY = 0
+        electrodeZ = 1
+
+        sigma = 1
+        r_limit = cell.d/2
+
+        value = lfpcalc._calc_lfp_linesource(cell.x[:, 0], cell.x[:, -1], 
+                                             cell.y[:, 0], cell.y[:, -1], 
+                                             cell.z[:, 0], cell.z[:, -1], 
+                                             electrodeX,electrodeY,electrodeZ, 
+                                             sigma,r_limit)
+
+        deltaS = 1
+        h_expected = 1
+        r_expected = 1
+        l_expected = 2
+
+        value_expected = 1/(4*np.pi*sigma*deltaS) * np.log( (l_expected+np.sqrt(l_expected**2+h_expected**2)) / (h_expected+np.sqrt(h_expected**2+r_expected**2)) ) 
+
+        np.testing.assert_almost_equal(value,value_expected)
+
+                                                             
+
 
 class DummyCell(CellGeometry):
     """CellGeometry like object with attributes for predicting extracellular

--- a/lfpykit/tests/test_lfpcalc.py
+++ b/lfpykit/tests/test_lfpcalc.py
@@ -635,8 +635,33 @@ class testLfpCalc(unittest.TestCase):
 
         np.testing.assert_almost_equal(value,value_expected)
 
-                                                             
+    def test_calc_lfp_linesource_backwards(self):
+        
+        '''Performs the same test as above, but with the first and last points of the neural segment reversed, to ensure that the result is not dependent on the choice of x_1 and x_2'''
 
+        cell = DummyCell(x=np.array([[1.,0.]]))
+
+        electrodeX = 2
+        electrodeY = 0
+        electrodeZ = 1
+
+        sigma = 1
+        r_limit = cell.d/2
+
+        value = lfpcalc._calc_lfp_linesource(cell.x[:, 0], cell.x[:, -1], 
+                                             cell.y[:, 0], cell.y[:, -1], 
+                                             cell.z[:, 0], cell.z[:, -1], 
+                                             electrodeX,electrodeY,electrodeZ, 
+                                             sigma,r_limit)
+
+        deltaS = 1
+        h_expected = 1
+        r_expected = 1
+        l_expected = 2
+
+        value_expected = 1/(4*np.pi*sigma*deltaS) * np.log( (l_expected+np.sqrt(l_expected**2+h_expected**2)) / (h_expected+np.sqrt(h_expected**2+r_expected**2)) ) 
+
+        np.testing.assert_almost_equal(value,value_expected)                                                            
 
 class DummyCell(CellGeometry):
     """CellGeometry like object with attributes for predicting extracellular


### PR DESCRIPTION
Hi all,
I believe that I have found a bug in the calculation of the line-source approximation. The value r2 should be the difference between l2 and the distance from the electrode to the start of the segment, not the difference between h2 and the electrode-segment distance. 